### PR TITLE
ADD: 숙소 상세페이지 API

### DIFF
--- a/controllers/room.js
+++ b/controllers/room.js
@@ -2,7 +2,14 @@ import * as roomService from '../services/room.js';
 
 export function roomsController(req, res) {}
 
-export function roomsDetailController(req, res) {}
+export async function roomsDetailController(req, res) {
+  try {
+    const result = await roomService.getRoomsById(null, req.params.id);
+    res.status(200).json({ data: result });
+  } catch (error) {
+    res.status(error.statusCode || 400).json({ message: error.message });
+  }
+}
 
 export function roomsLikeController(req, res) {}
 

--- a/controllers/room.js
+++ b/controllers/room.js
@@ -4,7 +4,10 @@ export function roomsController(req, res) {}
 
 export async function roomsDetailController(req, res) {
   try {
-    const result = await roomService.getRoomsById(null, req.params.id);
+    const result = await roomService.getRoomsById(null, req.params.id, {
+      start_date: req.query.start_date,
+      end_date: req.query.end_date,
+    });
     res.status(200).json({ data: result });
   } catch (error) {
     res.status(error.statusCode || 400).json({ message: error.message });

--- a/models/room.js
+++ b/models/room.js
@@ -2,7 +2,45 @@ import prismaClient from './prisma-client.js';
 
 export async function readAll() {}
 
-export async function readById(id) {}
+export async function checkId(roomId) {
+  const room = await prismaClient.$queryRaw`
+  SELECT * FROM rooms WHERE id=${roomId}`;
+  return room;
+}
+
+export async function readById(userId, roomId) {
+  const roomInfo = await prismaClient.$queryRawUnsafe(`SELECT
+rooms.title,
+rooms.province,
+rooms.city,
+rooms.concept,
+ri.images,
+rt.room,
+rs.specials,
+JSON_OBJECT('id',rooms_intro.id,'title ',rooms_intro.title, 'main_content',rooms_intro.main_content,'sub_content',rooms_intro.sub_content) intro,
+${userId ? `IFNULL(rooms_like.isLike,0) islike,` : ``}
+rooms.address
+
+FROM (SELECT id, title, concept, address, province, city FROM rooms GROUP BY id) rooms
+JOIN (SELECT rooms_image.rooms_id,JSON_ARRAYAGG(CASE WHEN rooms_image.id IS NOT NULL AND rooms_image.image IS NOT NULL THEN JSON_OBJECT('id', rooms_image.id, 'url',rooms_image.image) END)  images FROM rooms_image GROUP BY rooms_image.rooms_id) ri
+ON rooms.id = ri.rooms_id
+JOIN (SELECT room_type.rooms_id,JSON_ARRAYAGG(CASE WHEN room_type.id IS NOT NULL THEN JSON_OBJECT('id',room_type.id,'title',room_type.title,'type',room_type.type,'price',room_type.price,'image',rti.image) END) room FROM room_type JOIN (SELECT id,room_type_id,image FROM room_type_image GROUP BY room_type_image.room_type_id ORDER BY room_type_id) rti ON rti.room_type_id=room_type.id  GROUP BY room_type.rooms_id) rt
+ON rt.rooms_id = rooms.id
+${
+  userId
+    ? `LEFT JOIN (SELECT id,rooms_id, isLike FROM likes WHERE user_id=${userId} ) as rooms_like
+ON rooms_like.rooms_id = rooms.id`
+    : ``
+}
+JOIN rooms_intro
+ON rooms.id = rooms_intro.rooms_id
+JOIN (SELECT rooms_special.rooms_id,JSON_ARRAYAGG(CASE WHEN rooms_special.id IS NOT NULL THEN JSON_OBJECT('id',rooms_special.id,'title',rooms_special.title,'content',rooms_special.content,'image',rooms_special.image) END) specials FROM rooms_special GROUP BY rooms_special.rooms_id) rs
+ON rooms.id = rs.rooms_id
+WHERE rooms.id=${roomId}
+GROUP BY rooms.id`);
+
+  return roomInfo;
+}
 
 export async function createLike(id) {}
 

--- a/models/room.js
+++ b/models/room.js
@@ -9,7 +9,6 @@ export async function checkId(roomId) {
 }
 
 export async function readById(userId, roomId, date) {
-  console.log(date);
   const roomInfo = prismaClient.$queryRawUnsafe(`SELECT
 rooms.title,
 rooms.province,

--- a/routes/room.js
+++ b/routes/room.js
@@ -3,11 +3,11 @@ import * as roomController from '../controllers/room.js';
 
 const router = express.Router();
 
-router.get('/rooms', roomController.roomsController);
-router.get('/rooms/:id', roomController.roomsDetailController);
-router.post('/rooms/:id/like', roomController.roomsLikeController);
-router.get('/rooms/:id/room', roomController.roomsRoomController);
-router.get('/rooms/:id/bookings', roomController.roomsBookingInfoController);
-router.post('/rooms/payment', roomController.roomsPaymentController);
+router.get('/', roomController.roomsController);
+router.get('/:id', roomController.roomsDetailController);
+router.post('/:id/like', roomController.roomsLikeController);
+router.get('/:id/room', roomController.roomsRoomController);
+router.get('/:id/bookings', roomController.roomsBookingInfoController);
+router.post('/payment', roomController.roomsPaymentController);
 
 export default router;

--- a/services/room.js
+++ b/services/room.js
@@ -2,7 +2,16 @@ import * as roomRepositroy from '../models/room.js';
 
 export function getRooms() {}
 
-export function getRoomsById(id) {}
+export async function getRoomsById(userId, roomsId) {
+  const check = await roomRepositroy.checkId(roomsId);
+  if (!check.length) {
+    const error = new Error('해당 페이지가 존재하지 않습니다.');
+    error.statusCode = 404;
+    throw error;
+  } else {
+    return await roomRepositroy.readById(userId, roomsId);
+  }
+}
 
 export function likeRooms(id) {}
 

--- a/services/room.js
+++ b/services/room.js
@@ -2,14 +2,14 @@ import * as roomRepositroy from '../models/room.js';
 
 export function getRooms() {}
 
-export async function getRoomsById(userId, roomsId) {
+export async function getRoomsById(userId, roomsId, date) {
   const check = await roomRepositroy.checkId(roomsId);
   if (!check.length) {
     const error = new Error('해당 페이지가 존재하지 않습니다.');
     error.statusCode = 404;
     throw error;
   } else {
-    return await roomRepositroy.readById(userId, roomsId);
+    return await roomRepositroy.readById(userId, roomsId, date);
   }
 }
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 숙소 상세 페이지 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1.  숙소 리스트 페이지에서 특정 숙소 클릭 시  해당 숙소의 id값을 받아서 숙소 상세 페이지 구현
2. 숙소 상세 페이지에 필요한 방 종류별 데이터와 특징, 컨셉 등 데이터를 미리 약속한 형태로 전달
3. 전달 받은 숙소의 id값이 만약 존재하지 않는다면 에러처리 되도록 작성.
4. 숙소 상세 페이지에서 날짜를 선택하면 해당 날짜에 예약 가능한 방만 출력되도록 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 쿼리문을 작성할 때 여러 테이블을 조인할 때 원하는 데이터를 추출할 때 처음에는 쿼리를 잘 작성하지 못해서 카티션 곱 결과가 나왔는데, 서브 쿼리와 GROUP BY를 사용하여 작성한 후에 원하는 데이터를 추출할 수 있게 되었다.
- 쿼리를 작성할 때도 결국 맥락이 이어지도록 작성하는 것이 중요하다는 것을 다시 한 번 느꼈다. 

<br />

## :: 기타 질문 및 특이 사항

- 프론트와 실제 연결했을 때 에러 발생하면 추가 수정 하겠습니다.