### PR TITLE
Fix: 테마, 숙소 타입 필터링 다중 선택 가능하도록 쿼리 수정

### DIFF
--- a/models/room.js
+++ b/models/room.js
@@ -71,13 +71,13 @@ function generateHavingStatement({
     havingArray.push(`max_price < ${max_price}`);
   }
   if (type) {
-    havingArray.push(`type='${type}'`);
+    havingArray.push(`type IN (${type})`);
   }
   if (max_limit) {
     havingArray.push(`max_limit > ${max_limit}`);
   }
   if (theme) {
-    havingArray.push(`theme='${theme}'`);
+    havingArray.push(`theme IN (${theme})`);
   }
   return havingArray.length ? `HAVING ${havingArray.join(' and ')}` : '';
 }

--- a/models/room.js
+++ b/models/room.js
@@ -71,13 +71,23 @@ function generateHavingStatement({
     havingArray.push(`max_price < ${max_price}`);
   }
   if (type) {
-    havingArray.push(`type IN (${type})`);
+    havingArray.push(
+      `type IN (${type
+        .split(',')
+        .map(name => `'${name}'`)
+        .join(',')})`
+    );
   }
   if (max_limit) {
     havingArray.push(`max_limit > ${max_limit}`);
   }
   if (theme) {
-    havingArray.push(`theme IN (${theme})`);
+    havingArray.push(
+      `theme.name IN (${theme
+        .split(',')
+        .map(name => `'${name}'`)
+        .join(',')})`
+    );
   }
   return havingArray.length ? `HAVING ${havingArray.join(' and ')}` : '';
 }

--- a/server.js
+++ b/server.js
@@ -26,5 +26,5 @@ app.use('/mypage', myPageRouter);
 const server = http.createServer(app);
 const PORT = process.env.PORT || 10010;
 server.listen(PORT, () => {
-  console.log(`server start : http://13.125.249.195:${PORT}/`);
+  console.log(`server start PORT:${PORT}/`);
 });

--- a/services/room.js
+++ b/services/room.js
@@ -11,7 +11,6 @@ export async function accommodationList(userId, query) {
     max_limit: query.max_limit,
     theme: query.theme,
   };
-
   const sortKeyword = query.sort;
 
   const [accommodationList, accommodationCount] = await roomRepositroy.readAll(


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 테마, 숙소 타입 필터링 다중 선택 가능하도록 쿼리 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 테마, 숙소 타입 필터링 다중 선택 가능하도록 쿼리 수정
2. 숙소 타입과 테마가 ''로 묶여있지 않기 때문에 에러가 발생헤서 콤마를 기준으로 split하고 map함수를 돌려서 ''를 붙여주고 ','를 기준으로 join함수를 사용해서 해결

<br />

## :: 성장 포인트 

<br />

## :: 기타 질문 및 특이 사항

