### PR TITLE
Refactor: 함수명, 로직, 중복 데이터 처리, 페이지네이션 오프셋 값 확장성을 고려해 수정

### DIFF
--- a/controllers/mypage.js
+++ b/controllers/mypage.js
@@ -45,9 +45,11 @@ export async function wishList(req, res) {
   try {
     const page = req.query.page ? req.query.page : 1; // 받아오고 싶은 페이지
     const getImageAll = req.query.getImageAll; // 객체 전체사진 조회 여부
+    const count = req.query.count;
     const userId = req.userId; // 유저 고유 키
     const resData = await myPageService.getWishList({
       page,
+      count,
       userId,
       getImageAll,
     });
@@ -62,9 +64,11 @@ export async function reservationList(req, res) {
   try {
     const page = req.query.page ? req.query.page : 1; // 받아오고 싶은 페이지
     const getImageAll = req.query.getImageAll; // 객체 전체사진 조회 여부
+    const count = req.query.count;
     const userId = req.userId; // 유저 고유 키
     const resData = await myPageService.getReservationList({
       page,
+      count,
       userId,
       getImageAll,
     });

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -35,12 +35,3 @@ export const login = async (req, res) => {
       .json({ message: err.message, status: err.statusCode });
   }
 };
-
-export const me = async (req, res) => {
-  try {
-    await userService.me(req.userId);
-    res.status(200).json({ token: req.token });
-  } catch (error) {
-    res.status(error.statusCode || 500).json({ message: error.message });
-  }
-};

--- a/models/room.js
+++ b/models/room.js
@@ -6,7 +6,8 @@ export async function readAllAccommodations(
   keyword,
   filter,
   sortKeyword,
-  page
+  page,
+  limit
 ) {
   const sql = `SELECT
   rooms.id,
@@ -45,7 +46,7 @@ ${generateOrderByStatemnet(sortKeyword)}
     `SELECT COUNT(*) total_rows FROM (${sql}) t`
   );
   const rooms = await prismaClient.$queryRawUnsafe(
-    sql + generateLimitOffsetStatement(page)
+    sql + generateLimitOffsetStatement(page, limit)
   );
   return [rooms, roomsCnt];
 }
@@ -108,8 +109,7 @@ function generateJoinDateStatement(start_date, end_date) {
     : `JOIN room_type ON rooms.id = room_type.rooms_id`;
 }
 
-function generateLimitOffsetStatement(page) {
-  const limit = 6;
+function generateLimitOffsetStatement(page, limit) {
   return ` LIMIT ${limit} OFFSET ${limit * page}`;
 }
 

--- a/models/room.js
+++ b/models/room.js
@@ -1,6 +1,6 @@
 import prismaClient from './prisma-client.js';
 
-export async function readAll(
+export async function readAllAccommodations(
   userId,
   date,
   keyword,
@@ -113,13 +113,13 @@ function generateLimitOffsetStatement(page) {
   return ` LIMIT ${limit} OFFSET ${limit * page}`;
 }
 
-export async function checkId(accommodationId) {
+export async function checkAccommodationId(accommodationId) {
   const room = await prismaClient.$queryRaw`
   SELECT * FROM rooms WHERE id=${accommodationId}`;
   return room;
 }
 
-export async function readById(userId, accommodationId) {
+export async function readAccommodationById(userId, accommodationId) {
   const roomInfo = prismaClient.$queryRawUnsafe(`SELECT
   rooms.id,
   rooms.title,
@@ -152,7 +152,7 @@ GROUP BY rooms.id,rooms_intro.title,rooms_intro.main_content,rooms_intro.sub_con
   return roomInfo;
 }
 
-export async function roomImageById(date, accommodationId) {
+export async function readRooms(date, accommodationId) {
   const rooms = await prismaClient.$queryRawUnsafe(
     `SELECT rooms_id,JSON_ARRAYAGG(CASE WHEN room_type.id IS NOT NULL THEN JSON_OBJECT('id',room_type.id,'title',title,'type',type,'price',price,'image',rti.image,'max_limit',max_limit,'min_limit',min_limit) END) room FROM room_type JOIN (SELECT id,image FROM room_type_image) rti ON room_type.id=rti.id WHERE ${
       date.start_date && date.end_date
@@ -181,7 +181,7 @@ export async function checkLike(userId, accommodationId) {
   return result;
 }
 
-export async function roomById(roomTypeId, date) {
+export async function readRoomById(roomTypeId, date) {
   const room =
     await prismaClient.$queryRawUnsafe(`SELECT reservations.id,room_type.title room_name,rti.images ,room_type.check_in_time, room_type.check_out_time, room_type.price,${
       date.start_date && date.end_date
@@ -218,7 +218,7 @@ OR reservation.start_date IS NULL AND reservation.end_date IS NULL`
     : ``;
 };
 
-export async function readBookingInfo(roomTypeId, userId, date) {
+export async function getRoomTypeByUserId(roomTypeId, userId, date) {
   const timeDiff = `TIMESTAMPDIFF(DAY,'${date.start_date}','${date.end_date}')`;
   const result = await prismaClient.$queryRawUnsafe(`
   SELECT rooms.title rooms_name, room_type.title room_name, room_type.type , room_type.price, users.name user_name, users.phone phone_number, users.email, ${timeDiff} nights, ${timeDiff} * room_type.price total_price
@@ -243,7 +243,7 @@ export async function checkReservation(roomTypeId, start_date, end_date) {
   return check;
 }
 
-export async function payment(userId, roomTypeId, bookingInfo) {
+export async function createResevation(userId, roomTypeId, bookingInfo) {
   const result = prismaClient.$queryRawUnsafe(`
   INSERT INTO reservation(room_type_id,user_id,name,phone,email,number,start_date,end_date) VALUES(${roomTypeId},${userId},'${bookingInfo.name}','${bookingInfo.phone_number}','${bookingInfo.email}',${bookingInfo.number} ,'${bookingInfo.start_date}','${bookingInfo.end_date}');
   `);

--- a/models/user.js
+++ b/models/user.js
@@ -7,17 +7,12 @@ export const createUser = async (email, username, encryptPw, phoneNumber) => {
 
 export const readUserByEmail = async email => {
   return await prisma.$queryRaw`
-        SELECT users.email FROM users where email = ${email}`;
+        SELECT id,email,password FROM users where email = ${email}`;
 };
 
 export const getUserPasswordbyId = async user_id => {
   return await prisma.$queryRaw`
         SELECT password FROM users WHERE id=${user_id}`;
-};
-
-export const getUserIdByEmail = async email => {
-  return await prisma.$queryRaw`
-        SELECT id FROM users WHERE email = ${email}`;
 };
 
 export const getUserbyId = async user_id => {

--- a/models/user.js
+++ b/models/user.js
@@ -35,11 +35,3 @@ export const updatePassword = async (user_id, password) => {
     UPDATE users set password=${password} WHERE id=${user_id}
   `;
 };
-
-export async function readUserInfo(userId) {
-  const userInfo = await prisma.$queryRaw`
-  SELECT email, name FROM users WHERE id=${userId};
-  `;
-
-  return userInfo;
-}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model likes {
   rooms      rooms    @relation(fields: [rooms_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "likes_ibfk_2")
   users      users    @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "likes_ibfk_1")
 
+  @@unique([user_id, rooms_id], map: "user_id_2")
   @@index([rooms_id], map: "rooms_id")
   @@index([user_id], map: "user_id")
 }

--- a/routes/user.js
+++ b/routes/user.js
@@ -6,5 +6,4 @@ const router = express.Router();
 
 router.post('/signup', validateUser, userController.signUp);
 router.post('/login', userController.login);
-router.post('/me', validateToken, userController.me);
 export default router;

--- a/services/mypage.js
+++ b/services/mypage.js
@@ -44,49 +44,46 @@ export const updatePassword = async (
   return await userRepository.updatePassword(userId, encryptPassword);
 };
 
-export async function getWishList({ userId, page, getImageAll }) {
+export async function getWishList({ userId, page, getImageAll, count }) {
   const maxPage = await myPageRepository.readWishListRowCount(userId);
-  const data = await myPageRepository.readWishList(userId, page, getImageAll);
-  const count = 3;
+  const data = await myPageRepository.readWishList(userId, page, count);
   if (getImageAll === '1') {
     for (let i = 0; i < data.length; i++) {
-      delete data[i].concept;
-      delete data[i].type;
-      delete data[i].address;
-      delete data[i].check_in_time;
-      delete data[i].check_out_time;
-      delete data[i].user_id;
-      delete data[i].isLike;
-      delete data[i].created_at;
-      delete data[i].updated_at;
-
       data[i].image = await myPageRepository.readAccommodationImages(
-        data[i].id
+        data[i].rooms_id
       );
       data[i].image = data[i].image.map(image => image.image);
     }
+  } else {
+    for (let i = 0; i < data.length; i++) {
+      const image = await myPageRepository.readAccommodationImage(
+        data[i].rooms_id
+      );
+      data[i].image = image[0].image;
+    }
   }
-
   return {
     data,
     maxPage: Math.ceil(maxPage[0].cnt / count),
   };
 }
 
-export async function getReservationList({ userId, page, getImageAll }) {
+export async function getReservationList({ userId, page, getImageAll, count }) {
   const maxPage = await myPageRepository.readReservationRowCount(userId);
-  const data = await myPageRepository.readReservationList(
-    userId,
-    page,
-    getImageAll
-  );
-  const count = 3;
+  const data = await myPageRepository.readReservationList(userId, page, count);
   if (getImageAll === '1') {
     for (let i = 0; i < data.length; i++) {
       data[i].image = await myPageRepository.readAccommodationImages(
-        data[i].id
+        data[i].rooms_id
       );
       data[i].image = data[i].image.map(image => image.image);
+    }
+  } else {
+    for (let i = 0; i < data.length; i++) {
+      const image = await myPageRepository.readAccommodationImage(
+        data[i].rooms_id
+      );
+      data[i].image = image[0].image;
     }
   }
   return {

--- a/services/room.js
+++ b/services/room.js
@@ -14,14 +14,15 @@ export async function accommodationList(userId, query) {
   };
   const sortKeyword = query.sort;
 
-  const [accommodationList, accommodationCount] = await roomRepositroy.readAll(
-    userId,
-    date,
-    keyword,
-    filter,
-    sortKeyword,
-    page
-  );
+  const [accommodationList, accommodationCount] =
+    await roomRepositroy.readAllAccommodations(
+      userId,
+      date,
+      keyword,
+      filter,
+      sortKeyword,
+      page
+    );
 
   const result = accommodationList.map(accommodation => {
     return { ...accommodation, images: accommodation.images.filter(Boolean) };
@@ -30,14 +31,17 @@ export async function accommodationList(userId, query) {
 }
 
 export async function accommodationById(userId, roomsId, date) {
-  const check = await roomRepositroy.checkId(roomsId);
+  const check = await roomRepositroy.checkAccommodationId(roomsId);
   if (!check.length) {
     const error = new Error('해당 페이지가 존재하지 않습니다.');
     error.statusCode = 404;
     throw error;
   } else {
-    const accommodation = await roomRepositroy.readById(userId, roomsId);
-    const roomList = await roomRepositroy.roomImageById(date, roomsId);
+    const accommodation = await roomRepositroy.readAccommodationById(
+      userId,
+      roomsId
+    );
+    const roomList = await roomRepositroy.readRooms(date, roomsId);
     if (roomList.length) {
       accommodation[0].room = roomList[0].room;
       return accommodation;
@@ -55,7 +59,8 @@ export async function accommodationLike(userId, roomId) {
     return { isLike: true };
   } else {
     await roomRepositroy.updateLike(userId, roomId, !check.isLike);
-    return { isLike: !check.isLike };
+    const isLike = await roomRepositroy.checkLike(userId, roomId);
+    return { isLike: Boolean(isLike.isLike) };
   }
 }
 
@@ -63,7 +68,7 @@ export async function roomById(id, date) {
   console.log(id, date);
   const check = await roomRepositroy.roomCheck(id);
   if (!!check.length) {
-    const result = await roomRepositroy.roomById(id, date);
+    const result = await roomRepositroy.readRoomById(id, date);
     return result;
   } else {
     const error = new Error('Page Not Found');
@@ -79,14 +84,17 @@ export async function reservationInfo(roomTypeId, userId, date) {
     date.start_date,
     date.end_date
   );
-
-  if (!!duplicateCheck.length) {
-    const error = new Error('해당 날짜는 예약이 마감되었습니다.');
-    error.statusCode = 400;
-    throw error;
-  }
   if (!!check.length) {
-    const data = await roomRepositroy.readBookingInfo(roomTypeId, userId, date);
+    if (!!duplicateCheck.length) {
+      const error = new Error('해당 날짜는 예약이 마감되었습니다.');
+      error.statusCode = 400;
+      throw error;
+    }
+    const data = await roomRepositroy.getRoomTypeByUserId(
+      roomTypeId,
+      userId,
+      date
+    );
     return data;
   } else {
     const error = new Error('Page Not Found');
@@ -107,6 +115,10 @@ export async function payment(userId, roomTypeId, bookingInfo) {
     error.statusCode = 400;
     throw error;
   } else {
-    return await roomRepositroy.payment(userId, roomTypeId, bookingInfo);
+    return await roomRepositroy.createResevation(
+      userId,
+      roomTypeId,
+      bookingInfo
+    );
   }
 }

--- a/services/room.js
+++ b/services/room.js
@@ -3,6 +3,7 @@ import * as roomRepositroy from '../models/room.js';
 export async function accommodationList(userId, query) {
   const date = { start_date: query.start_date, end_date: query.end_date };
   const page = parseInt(query.page ? query.page : 1) - 1;
+  const limit = parseInt(query.limit ? query.limit : 6);
   const keyword = query.search;
   const filter = {
     min_price: query.min_price,
@@ -21,7 +22,8 @@ export async function accommodationList(userId, query) {
       keyword,
       filter,
       sortKeyword,
-      page
+      page,
+      limit
     );
 
   const result = accommodationList.map(accommodation => {

--- a/services/user.js
+++ b/services/user.js
@@ -89,13 +89,3 @@ export const login = async (email, password) => {
   const token = jwt.sign({ id }, process.env.SECRET_KEY);
   return token;
 };
-
-export const me = async userId => {
-  const user = await userRepository.getUserbyId(userId);
-  if (user.length === 0) {
-    const error = new Error('User Not Found');
-    error.statusCode = 404;
-    throw error;
-  }
-  return;
-};

--- a/services/user.js
+++ b/services/user.js
@@ -7,6 +7,7 @@ dotenv.config();
 
 export const signUp = async (email, username, password, phoneNumber) => {
   //password validation
+  const [userInfo] = await userRepository.readUserByEmail(email);
   const passwordValidation = new RegExp(
     '^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[!@#$%^&*])(?=.{8,20})'
   );
@@ -17,8 +18,7 @@ export const signUp = async (email, username, password, phoneNumber) => {
   }
 
   //중복 이메일
-  const userEmail = await userRepository.readUserByEmail(email);
-  if (userEmail.length) {
+  if (userInfo) {
     const err = new Error('EXISTING_USER');
     err.statusCode = 409;
     throw err;
@@ -65,19 +65,15 @@ export const signUp = async (email, username, password, phoneNumber) => {
 
 export const login = async (email, password) => {
   //회원가입한 유저인지 확인
-  const user = await userRepository.readUserByEmail(email);
-  if (user.length === 0) {
+  const [userInfo] = await userRepository.readUserByEmail(email);
+  if (!userInfo) {
     const error = new Error('INVALID_USER');
     error.statusCode = 400;
     throw error;
   }
 
   //비밀번호 확인
-  const inputPassword = await userRepository.passwordIsCorrect(email);
-  const passwordIsCorrect = await bcrypt.compare(
-    password,
-    inputPassword[0].password
-  );
+  const passwordIsCorrect = await bcrypt.compare(password, userInfo.password);
 
   if (!passwordIsCorrect) {
     const error = new Error('INVALID_USER');
@@ -85,7 +81,6 @@ export const login = async (email, password) => {
     throw error;
   }
 
-  const [{ id }] = await userRepository.getUserIdByEmail(email);
-  const token = jwt.sign({ id }, process.env.SECRET_KEY);
+  const token = jwt.sign({ id: userInfo.id }, process.env.SECRET_KEY);
   return token;
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 함수명, 로직, 중복 데이터 처리, 페이지네이션 오프셋 값 확장성을 고려해 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 로그인, 회원가입

- email, password를 두 번 쿼리 요청을 날려서 받는 부분을 한 번 요청할 때 email,password 받을 수 있게 로직 수정

2. models의 함수명 변경
- 직관적으로 이해할 수 있도록 동사를 앞에 붙이고 뒤에 엔티티명을 입력하는 컨벤션으로 수정

3. likes 테이블 user_id, rooms_id 컬럼 유니크 조건 추가
- 검색할 때 모든 로우를 확인하면 시간이 더 오래 걸리므로 유니크 조건 추가

4. likes 메서드 구현 로직 중에 likes테이블에 로우가 있다면 변경되는 값을 임의로 응답 메시지에 넣어서 전달했는데,  Update 쿼리 요청이 이뤄진 후에 체크 메서드를 통해 쿼리 요청을 보내 isLike 값을 받은 후 응답 메시지에 전달하는 형태로 수정.

5. 페이지네이션을 할 때 오프셋 부분에 들어가는 limit 값을 원래는 model의 해당 메서드 안에 상수 변수로 선언하여 사용하였는데, 추후 확장성을 위해 클라이언트에서 받는 부분으로 수정.
- 현재는 클라이언트에서 전달해주는 로직으로 짜여져 있지 않기 때문에, 삼항연산자를 사용하여 처리.

6. 사용하지 않는 me, readUserInfo 메서드 삭제


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 하나의 요청으로 받을 수 있는 데이터를 여러 번 쿼리 요청을 보내는 일이 앞으로는 적어지지 않을까 생각합니다..
- 임의로 isLike 값을 보내는 경우 중간에 특이 사항(에러로 인한 수정 미반영)이 발상할 때 잘못된 isLike 값이 전달될 수 있다는 것을 알고, 앞으로는 신경써서 응답값을 보낼 것 같습니다.
- 함수명 컨벤션.. 매우 중요한 것 같습니다.. 코드를 작성하고 사용하면서도 직관적이지 않은 함수명 때문에 헷갈렸던 적이 있는데 컨벤션을 지켜서 작성하면 모호한 함수명 때문에 소요되는 시간을 줄일 수 있을 것 같습니다.

<br />

## :: 기타 질문 및 특이 사항

